### PR TITLE
Update for Minitest 5.0.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     minitest-matchers (1.3.0)
-      minitest (~> 4.7)
+      minitest (~> 5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (4.7.5)
+    minitest (5.0.6)
     rake (10.1.0)
 
 PLATFORMS

--- a/lib/minitest/matchers.rb
+++ b/lib/minitest/matchers.rb
@@ -53,7 +53,7 @@ module MiniTest
 
   module Expectations
     ##
-    # See MiniTest::Assertions#assert_must
+    # See Minitest::Assertions#assert_must
     #
     #     user.must have_valid(:email).when("user@example.com")
     #
@@ -62,7 +62,7 @@ module MiniTest
     infect_an_assertion :assert_must, :must
 
     ##
-    # See MiniTest::Assertions#assert_wont
+    # See Minitest::Assertions#assert_wont
     #
     #     user.wont have_valid(:email).when("bad@email")
     #
@@ -72,7 +72,7 @@ module MiniTest
   end
 end
 
-class MiniTest::Spec
+class Minitest::Spec
   ##
   # Expects that matcher matches the subject
   #
@@ -132,7 +132,7 @@ class MiniTest::Spec
   end
 end
 
-class MiniTest::Unit::TestCase
+class Minitest::Test
   ##
   # Defines assert_* assertion and must_* expectation for a matcher
   #
@@ -144,7 +144,7 @@ class MiniTest::Unit::TestCase
   #     # ...
   #   end
   #
-  #   MiniTest::Unit::TestCase.register_matcher HaveContent, :have_content
+  #   Minitest::Unit::TestCase.register_matcher HaveContent, :have_content
   #
   #   class MyTest < Test::Unit::TestCase
   #     def test_index
@@ -197,6 +197,6 @@ class MiniTest::Unit::TestCase
   end
 end
 
-class MiniTest::Spec # :nodoc:
-  include MiniTest::Matchers
+class Minitest::Spec # :nodoc:
+  include Minitest::Matchers
 end

--- a/lib/minitest/matchers/version.rb
+++ b/lib/minitest/matchers/version.rb
@@ -1,4 +1,4 @@
-module MiniTest
+module Minitest
   module Matchers
     VERSION = File.read(File.expand_path("../../../../VERSION", __FILE__)).strip
   end

--- a/minitest-matchers.gemspec
+++ b/minitest-matchers.gemspec
@@ -4,7 +4,7 @@ require "minitest/matchers/version"
 
 Gem::Specification.new do |s|
   s.name        = "minitest-matchers"
-  s.version     = MiniTest::Matchers::VERSION
+  s.version     = Minitest::Matchers::VERSION
   s.authors     = ["Wojciech Mach", "Ryan Davis"]
   s.email       = ["wojtek@wojtekmach.pl", "ryand-ruby@zenspider.com"]
   s.homepage    = ""
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "minitest", "~> 4.7"
+  s.add_dependency "minitest", "~> 5.0"
 
   s.add_development_dependency "rake"
 end

--- a/test/minitest/matchers_test.rb
+++ b/test/minitest/matchers_test.rb
@@ -1,5 +1,4 @@
 gem "minitest"
-require "minitest/spec"
 require "minitest/autorun"
 require "minitest/matchers"
 
@@ -31,82 +30,75 @@ def be_kind_of klass
   KindOfMatcher.new klass
 end
 
-describe MiniTest::Unit::TestCase do
+describe Minitest::Test do
   it "needs to verify assert_must" do
     assert_must(be_kind_of(Array), []).must_equal true
-    proc { assert_must be_kind_of(String), [] }.must_raise MiniTest::Assertion
+    proc { assert_must be_kind_of(String), [] }.must_raise Minitest::Assertion
   end
 
   it "needs to verify assert_wont" do
     assert_wont(be_kind_of(String), []).must_equal false
-    proc { assert_wont be_kind_of(Array), [] }.must_raise MiniTest::Assertion
+    proc { assert_wont be_kind_of(Array), [] }.must_raise Minitest::Assertion
   end
 end
 
-describe MiniTest::Unit::TestCase, :register_matcher do
-  MiniTest::Unit::TestCase.register_matcher KindOfMatcher, :my_kind_of, :be_my_kind_of
-  MiniTest::Unit::TestCase.register_matcher :be_kind_of, :meth_kind_of, :meth_my_kind_of
+describe Minitest::Test, :register_matcher do
+  Minitest::Test.register_matcher KindOfMatcher, :my_kind_of, :be_my_kind_of
+  Minitest::Test.register_matcher :be_kind_of, :meth_kind_of, :meth_my_kind_of
 
   it "needs to verify assert_<matcher>" do
     assert_my_kind_of("", String).must_equal true
-    proc { assert_my_kind_of [], String }.must_raise MiniTest::Assertion
+    proc { assert_my_kind_of [], String }.must_raise Minitest::Assertion
   end
 
   it "needs to verify must_<matcher>" do
     "".must_be_my_kind_of(String).must_equal true
-    proc { [].must_be_my_kind_of String }.must_raise MiniTest::Assertion
+    proc { [].must_be_my_kind_of String }.must_raise Minitest::Assertion
   end
 
   it "needs to verify refute_<matcher>" do
     refute_my_kind_of("", Array).must_equal false
-    proc { refute_my_kind_of [], Array }.must_raise MiniTest::Assertion
+    proc { refute_my_kind_of [], Array }.must_raise Minitest::Assertion
   end
 
   it "needs to verify wont<matcher>" do
     "".wont_be_my_kind_of(Array).must_equal false
-    proc { [].wont_be_my_kind_of(Array) }.must_raise MiniTest::Assertion
+    proc { [].wont_be_my_kind_of(Array) }.must_raise Minitest::Assertion
   end
 
   it "accepts method as matcher" do
     assert_meth_kind_of("", String).must_equal true
-    proc { assert_meth_kind_of [], String }.must_raise MiniTest::Assertion
+    proc { assert_meth_kind_of [], String }.must_raise Minitest::Assertion
     refute_meth_kind_of("", Array).must_equal false
-    proc { refute_my_kind_of [], Array }.must_raise MiniTest::Assertion
+    proc { refute_my_kind_of [], Array }.must_raise Minitest::Assertion
   end
 end
 
-describe MiniTest::Spec do
+describe Minitest::Spec do
   it "needs to verify must" do
     [].must(be_kind_of(Array)).must_equal true
-    proc { [].must be_kind_of(String) }.must_raise MiniTest::Assertion
+    proc { [].must be_kind_of(String) }.must_raise Minitest::Assertion
   end
 
   it "needs to verify wont" do
     [].wont(be_kind_of(String)).must_equal false
-    proc { [].wont be_kind_of(Array) }.must_raise MiniTest::Assertion
+    proc { [].wont be_kind_of(Array) }.must_raise Minitest::Assertion
   end
 
-  it "needs to verify must with implicit subject" do
-    spec_class = Class.new(MiniTest::Spec) do
-      subject { [1, 2, 3] }
+  describe "implicit subject" do
+    subject { [1, 2, 3] }
 
-      it { must be_kind_of(String) }
+    must { be_kind_of(Array) }
+    wont { be_kind_of(String) }
+
+    it "verifies must" do
+      must be_kind_of(Array)
+      proc { must be_kind_of(String) }.must_raise Minitest::Assertion
     end
 
-    spec = spec_class.new("A spec")
-
-    proc { spec.send spec_class.test_methods.first}.must_raise MiniTest::Assertion
-  end
-
-  it "needs to verify wont with implicit subject" do
-    spec_class = Class.new(MiniTest::Spec) do
-      subject { [1, 2, 3] }
-
-      it { wont be_kind_of(Array) }
+    it "verifies wont" do
+      wont be_kind_of(String)
+      proc { wont be_kind_of(Array) }.must_raise Minitest::Assertion
     end
-
-    spec = spec_class.new("A spec")
-
-    proc { spec.send spec_class.test_methods.first}.must_raise MiniTest::Assertion
   end
 end


### PR DESCRIPTION
General updates for Minitest 5.0 compatibility and updates for implicit
subject testing.
- MiniTest -> Minitest
- MiniTest::Unit::TestCase -> Minitest::Test
- Remove anonymous classes for testing the implicit subject
- Add tests for `.must` and `.wont`
- Add true cases for `must` and `wont` with implicit subject

Thanks to @phlipper for his grit and determination. I couldn't have done it without you! :cry: :birthday: 
