### PR TITLE
CI: Drop unused Travis directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 rvm:
 - 2.3.0
 
-sudo: false
 cache: bundler
 script: RUBYOPT="-w $RUBYOPT" bundle exec rake


### PR DESCRIPTION
  - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for details